### PR TITLE
users: arreglar bug de CORS e include #122

### DIFF
--- a/users/config/app.js
+++ b/users/config/app.js
@@ -22,7 +22,7 @@ try {
 
 // Cabeceras CORS
 app.use((req, res, next) => {
-  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Origin', process.env.CORS_ORIGIN ?? 'http://localhost:5173');
   res.setHeader('Access-Control-Allow-Credentials', 'true');
   res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');

--- a/webapp/src/__tests__/GamePage.test.tsx
+++ b/webapp/src/__tests__/GamePage.test.tsx
@@ -43,7 +43,7 @@ describe('GamePage', () => {
     )
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith('http://localhost:4000/status', {credentials: "include"})
+      expect(global.fetch).toHaveBeenCalledWith('http://localhost:4000/status', {})
     })
   })
 

--- a/webapp/src/pages/GamePage.tsx
+++ b/webapp/src/pages/GamePage.tsx
@@ -16,7 +16,7 @@ const GamePage = ({user}: GamePageProps) => {
     const checkGameyStatus = async () => {
       try {
         const GAMEY_URL = import.meta.env.VITE_GAMEY_URL ?? 'http://localhost:4000';
-        const res = await fetch(`${GAMEY_URL}/status`, {credentials: "include"});
+        const res = await fetch(`${GAMEY_URL}/status`, {});
         const data = await res.text();
         
         if (res.ok && data.trim() === 'OK') {


### PR DESCRIPTION
La propiedad credentials de fetch requiere que se mande un Origin específico para el CORS. Ahora se envía el origin correcto obtenido de variable de entorno (o por defecto para desarrollo)