### PR TITLE
webapp: arreglar desplegable dificultad #184

### DIFF
--- a/webapp/src/__tests__/Board.test.tsx
+++ b/webapp/src/__tests__/Board.test.tsx
@@ -22,7 +22,7 @@ describe('Pruebas unitarias del Tablero (Board)', () => {
   })
 
   it('debería renderizar el tablero inicial correctamente', () => {
-    const { container } = render(<Board boardSize={5} botId="random_bot" difficulty="easy" gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
+    const { container } = render(<Board boardSize={5} botId="random_bot"  gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
 
     expect(screen.getByText(/Tu turno \(Juegas con Azul\)/i)).toBeTruthy()
     // Tablero tamaño 5 = 15 hexágonos
@@ -31,7 +31,7 @@ describe('Pruebas unitarias del Tablero (Board)', () => {
   })
 
   it('debería llamar a la API y cambiar el estado al hacer clic en un hexágono', async () => {
-    const { container } = render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
+    const { container } = render(<Board boardSize={3} botId="random_bot"  gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
     const hexagons = container.querySelectorAll('polygon')
 
     fireEvent.click(hexagons[0])
@@ -56,7 +56,7 @@ describe('Pruebas unitarias del Tablero (Board)', () => {
       }),
     } as Response)
 
-    const { container } = render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
+    const { container } = render(<Board boardSize={3} botId="random_bot"  gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
     const hexagons = container.querySelectorAll('polygon')
 
     fireEvent.click(hexagons[0])
@@ -78,7 +78,7 @@ describe('Pruebas unitarias del Tablero (Board)', () => {
       }),
     } as Response)
 
-    const { container } = render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
+    const { container } = render(<Board boardSize={3} botId="random_bot"  gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
     const hexagons = container.querySelectorAll('polygon')
 
     fireEvent.click(hexagons[0])
@@ -93,7 +93,7 @@ describe('Pruebas unitarias del Tablero (Board)', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     global.fetch = vi.fn().mockRejectedValueOnce(new Error('Bot server down'))
 
-    const { container } = render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
+    const { container } = render(<Board boardSize={3} botId="random_bot"  gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
     fireEvent.click(container.querySelectorAll('polygon')[0])
 
     await waitFor(() => {
@@ -115,7 +115,7 @@ describe('Pruebas unitarias del Tablero (Board)', () => {
       }),
     } as Response)
 
-    const { container } = render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
+    const { container } = render(<Board boardSize={3} botId="random_bot"  gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
     fireEvent.click(container.querySelectorAll('polygon')[0])
 
     await waitFor(() => {
@@ -126,7 +126,7 @@ describe('Pruebas unitarias del Tablero (Board)', () => {
 
   it('debería renderizar el número correcto de hexágonos para un tamaño de tablero personalizado', () => {
     // Tablero tamaño 3 = 3*4/2 = 6 hexágonos
-    const { container } = render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
+    const { container } = render(<Board boardSize={3} botId="random_bot"  gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
 
     const hexagons = container.querySelectorAll('polygon')
     expect(hexagons.length).toBe(6)
@@ -148,13 +148,13 @@ describe('Pruebas del modo PvP (Jugador vs Jugador)', () => {
   })
 
   it('debería mostrar el turno del Jugador 1 al inicio en modo PvP', () => {
-    render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="pvp" player1Name="Guille" player2Name="Pepe"/>)
+    render(<Board boardSize={3} botId="random_bot"  gameMode="pvp" player1Name="Guille" player2Name="Pepe"/>)
 
     expect(screen.getByText(/Turno de Guille \(Azul\)/i)).toBeTruthy()
   })
 
   it('debería alternar al turno del Jugador 2 tras el movimiento del Jugador 1', async () => {
-    const { container } = render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="pvp" player1Name="Guille" player2Name="Pepe"/>)
+    const { container } = render(<Board boardSize={3} botId="random_bot"  gameMode="pvp" player1Name="Guille" player2Name="Pepe"/>)
 
     fireEvent.click(container.querySelectorAll('polygon')[0])
 
@@ -173,7 +173,7 @@ describe('Pruebas del modo PvP (Jugador vs Jugador)', () => {
     })
     } as Response)
 
-    const { container } = render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="pvp" player1Name="Guille" player2Name="Pepe"/>)
+    const { container } = render(<Board boardSize={3} botId="random_bot"  gameMode="pvp" player1Name="Guille" player2Name="Pepe"/>)
     fireEvent.click(container.querySelectorAll('polygon')[0])
 
     await waitFor(() => {
@@ -199,7 +199,7 @@ describe('Pruebas del modo PvP (Jugador vs Jugador)', () => {
         }),
       } as Response)
 
-    const { container } = render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="pvp" player1Name="Guille" player2Name="Pepe"/>)
+    const { container } = render(<Board boardSize={3} botId="random_bot"  gameMode="pvp" player1Name="Guille" player2Name="Pepe"/>)
     const hexagons = container.querySelectorAll('polygon')
 
     // J1 mueve
@@ -226,7 +226,7 @@ describe('Pruebas del modo PvP (Jugador vs Jugador)', () => {
       }),
     } as Response)
 
-    const { container } = render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="pvp" player1Name="Guille" player2Name="Pepe"/>)
+    const { container } = render(<Board boardSize={3} botId="random_bot"  gameMode="pvp" player1Name="Guille" player2Name="Pepe"/>)
     fireEvent.click(container.querySelectorAll('polygon')[0])
 
     // La partida continúa: se muestra el turno de J2
@@ -255,7 +255,7 @@ describe('Pruebas de la sugerencia de movimiento (bridgebot)', () => {
   })
  
   it('debería mostrar el botón de sugerencia habilitado al inicio de la partida', () => {
-    render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
+    render(<Board boardSize={3} botId="random_bot"  gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
  
     const btn = screen.getByRole('button', { name: /Sugerir movimiento/i }) as HTMLButtonElement
     expect(btn).toBeTruthy()
@@ -263,7 +263,7 @@ describe('Pruebas de la sugerencia de movimiento (bridgebot)', () => {
   })
  
   it('debería llamar al endpoint de bridgebot con turn=0 cuando el humano pide sugerencia', async () => {
-    render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
+    render(<Board boardSize={3} botId="random_bot"  gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
  
     fireEvent.click(screen.getByRole('button', { name: /Sugerir movimiento/i }))
  
@@ -279,7 +279,7 @@ describe('Pruebas de la sugerencia de movimiento (bridgebot)', () => {
   })
  
   it('debería resaltar en dorado la casilla sugerida por el bridgebot', async () => {
-    const { container } = render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
+    const { container } = render(<Board boardSize={3} botId="random_bot"  gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
  
     // Antes de pedir sugerencia, ningún hexágono está dorado
     const doradosAntes = Array.from(container.querySelectorAll('polygon'))
@@ -297,7 +297,7 @@ describe('Pruebas de la sugerencia de movimiento (bridgebot)', () => {
   })
  
   it('debería deshabilitar el botón tras pedir la sugerencia y mostrar "Sugerencia ya utilizada"', async () => {
-    render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
+    render(<Board boardSize={3} botId="random_bot"  gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
  
     fireEvent.click(screen.getByRole('button', { name: /Sugerir movimiento/i }))
  
@@ -332,7 +332,7 @@ describe('Pruebas de la sugerencia de movimiento (bridgebot)', () => {
       } as Response)
     })
  
-    const { container } = render(<Board boardSize={3} botId="random_bot" difficulty="easy" gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
+    const { container } = render(<Board boardSize={3} botId="random_bot"  gameMode="bot" player1Name="Jugador" player2Name="Invitado"/>)
  
     // Pide sugerencia y espera a que aparezca el dorado
     fireEvent.click(screen.getByRole('button', { name: /Sugerir movimiento/i }))

--- a/webapp/src/__tests__/GamePage.test.tsx
+++ b/webapp/src/__tests__/GamePage.test.tsx
@@ -99,4 +99,24 @@ describe('GamePage', () => {
     // Texto de PlayPage
     expect(await screen.findByText(/Es tu turno/i))
   })
+
+  it('debería funcionar correctamente el botón de seleccionar dificultad', async () => {
+    render(
+      <GamePage user={{id:"1", nombre: "Pepe", nom_usuario:"pepe" }}/>
+    )
+
+    expect(screen.getByText('Bot Aleatorio (Fácil)')).toBeTruthy()
+    screen.getByRole('option', { name: /Bot Medio \(Medio\)/i }).click();
+    expect(screen.getByText('Bot Medio (Medio)')).toBeTruthy()
+  })
+
+  it('debería funcionar correctamente el botón de selector tamaño de tablero', async () => {
+    render(
+      <GamePage user={{id:"1", nombre: "Pepe", nom_usuario:"pepe" }}/>
+    )
+
+    expect(screen.getByText('Tablero pequeño')).toBeTruthy()
+    screen.getByRole('option', { name: /Tablero mediano/i }).click();
+    expect(screen.getByText('Tablero grande')).toBeTruthy()
+  })
 })

--- a/webapp/src/__tests__/GamePage.test.tsx
+++ b/webapp/src/__tests__/GamePage.test.tsx
@@ -87,4 +87,16 @@ describe('GamePage', () => {
       expect(screen.getByPlaceholderText(/Nombre del Jugador 2/i)).toBeTruthy()
     })
   })
+
+  it('debería funcionar correctamente el botón de jugar', async () => {
+    render(
+      <GamePage user={{id:"1", nombre: "Pepe", nom_usuario:"pepe" }}/>
+    )
+
+    const playButton = await screen.findByRole('button', { name: /JUGAR/i })
+    playButton.click();
+
+    // Texto de PlayPage
+    expect(await screen.findByText(/Es tu turno/i))
+  })
 })

--- a/webapp/src/__tests__/PlayPage.test.tsx
+++ b/webapp/src/__tests__/PlayPage.test.tsx
@@ -26,7 +26,8 @@ describe('Pruebas unitarias de la página de Partida (PlayPage)', () => {
 
   it('debería extraer el nombre de usuario de la sesión y mostrarlo en el título', async () => {
     render(
-        <PlayPage boardSize={3} user={{id:"1", nombre: "Pepe", nom_usuario:"pepe" }} botId="random_bot" gameMode="bot" player2Name="Invitado" onBackToLobby={()=>{}}/>
+        <PlayPage boardSize={3} user={{id:"1", nombre: "Pepe", nom_usuario:"pepe" }} botId="random_bot" gameMode="bot" player2Name="Invitado" onBackToLobby={()=>{}}
+            onChangeDifficulty={()=>{}}/>
     )
 
     // Comprobamos que el nombre aparece en la pantalla
@@ -36,7 +37,8 @@ describe('Pruebas unitarias de la página de Partida (PlayPage)', () => {
 
   it('debería renderizar el componente Board (Tablero)', async () => {
     render(
-        <PlayPage boardSize={3} user={{id:"1", nombre: "Pepe", nom_usuario:"pepe" }} botId="random_bot" gameMode="bot" player2Name="Invitado" onBackToLobby={()=>{}}/>
+        <PlayPage boardSize={3} user={{id:"1", nombre: "Pepe", nom_usuario:"pepe" }} botId="random_bot" gameMode="bot" player2Name="Invitado" onBackToLobby={()=>{}}
+            onChangeDifficulty={()=>{}}/>
     )
 
     // Buscamos nuestro tablero "mockeado"
@@ -45,7 +47,8 @@ describe('Pruebas unitarias de la página de Partida (PlayPage)', () => {
 
   it('debería mostrar los nombres de ambos jugadores en el título en modo PvP', async () => {
     render(
-      <PlayPage boardSize={3} user={{id:"1", nombre: "Pepe", nom_usuario:"Guille"}} botId="random_bot" gameMode="pvp" player2Name="Pepe" onBackToLobby={() => {}}/>
+      <PlayPage boardSize={3} user={{id:"1", nombre: "Pepe", nom_usuario:"Guille"}} botId="random_bot" gameMode="pvp" player2Name="Pepe" onBackToLobby={() => {}}
+            onChangeDifficulty={()=>{}}/>
     )
 
     expect(await screen.findByText('Guille')).toBeTruthy()

--- a/webapp/src/__tests__/PlayPage.test.tsx
+++ b/webapp/src/__tests__/PlayPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, userEvent, fireEvent, waitFor } from '@testing-library/react'
 import { vi, beforeEach, describe, it, expect } from 'vitest'
 import PlayPage from '../pages/PlayPage'
 import GamePage from '../pages/GamePage'
@@ -76,5 +76,16 @@ describe('Pruebas unitarias de la página de Partida (PlayPage)', () => {
     await waitFor(() => {
       expect(screen.getByText('Juego Y')).toBeTruthy()
     })
+  })
+
+  it('debería cambiar de dificultad correctamente', async () => {
+    render(
+      <PlayPage boardSize={3} user={{id:"1", nombre: "Pepe", nom_usuario:"Guille"}} botId="random_bot" gameMode="bot" player2Name="Invitado" onBackToLobby={() => {}}
+            onChangeDifficulty={()=>{}}/>
+    )
+
+    expect(screen.getByText('Dificultad: Fácil')).toBeTruthy()
+    screen.getByRole('option', { name: /Dificultad: Medio/i }).click();
+    expect(screen.getByText('Dificultad: Medio')).toBeTruthy()
   })
 })

--- a/webapp/src/components/Board.tsx
+++ b/webapp/src/components/Board.tsx
@@ -3,7 +3,6 @@ import { Hexagon } from './Hexagon';
 
 type BoardProps = {
     botId: string;
-    difficulty: 'easy' | 'medium' | 'hard';
     boardSize: number;                    // número de hexágonos por lado del triángulo (5, 10 o 15)
     gameMode: 'bot' | 'pvp';             // 'bot' = jugador vs IA  |  'pvp' = dos jugadores locales
     player1Name: string;                  // nombre del usuario autenticado
@@ -40,7 +39,7 @@ type StatusResponse = { // respuesta del endpoint /v1/ybot/status de Gamey
     status: GameStatus;   // estado de la partida tras evaluar el tablero
 };
 
-export const Board = ({botId, difficulty, boardSize, gameMode, player1Name, player2Name}: BoardProps) => {
+export const Board = ({botId, boardSize, gameMode, player1Name, player2Name}: BoardProps) => {
 
   // Calcula el tamaño del hexágono para que el tablero quepa en el SVG
   const SVG_W = 600;
@@ -86,8 +85,6 @@ export const Board = ({botId, difficulty, boardSize, gameMode, player1Name, play
     }
   };
 
-  console.debug(botId);
-
   // Convierte el estado del tablero al formato YEN que espera Gamey.
   // Layout: filas separadas por '/', cada carácter es B / R / .
   const generarYEN = (currentBoard: Record<string, CellState>, turn: number = 1): object => {
@@ -110,12 +107,6 @@ export const Board = ({botId, difficulty, boardSize, gameMode, player1Name, play
     return { size: boardSize, turn, players: ["B", "R"], layout: filas.join("/") };
   };
 
-  const BOT_ENDPOINTS: Record<string, string> = { // mapeo de dificultad al identificador del bot en Gamey
-    easy:   'random_bot',
-    medium: 'mediumbot',
-    hard:   'bridgebot'
-  };
-
   // Envía el tablero a Gamey y coloca el movimiento devuelto por el bot.
   // Si el humano ya ganó antes de que el bot mueva, no coloca ficha del bot.
   const askBotForMove = async (currentBoard: Record<string, CellState>) => {
@@ -123,7 +114,7 @@ export const Board = ({botId, difficulty, boardSize, gameMode, player1Name, play
     try {
       const GAMEY_URL = import.meta.env.VITE_GAMEY_URL ?? 'http://localhost:4000';
       const yenPayload = generarYEN(currentBoard); // turn=1 por defecto: le toca al bot como player 1
-      const botEndpoint = BOT_ENDPOINTS[difficulty];
+      const botEndpoint = botId
 
       const res = await fetch(`${GAMEY_URL}/v1/ybot/choose/${botEndpoint}`, {
         method: 'POST',
@@ -249,7 +240,7 @@ export const Board = ({botId, difficulty, boardSize, gameMode, player1Name, play
   const salvarPartidaEnBD = async (userWon: boolean, oponenteName?: string) => {
     try {
       const USERS_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:3000';
-      const oponente = oponenteName ?? BOT_ENDPOINTS[difficulty];
+      const oponente = oponenteName ?? botId
 
       const res = await fetch(`${USERS_URL}/guardar-partida`, {
         method: 'POST',

--- a/webapp/src/pages/GamePage.tsx
+++ b/webapp/src/pages/GamePage.tsx
@@ -16,9 +16,8 @@ const GamePage: React.FC<GamePageProps> = ({ user }) => {
   const [playGame, setPlayGame] = useState(false);
   const [viewStats, setViewStats] = useState(false);
 
-// botId guardará el nombre del archivo (sin .rs) que usará gamey
+// botId es el nombre de bot de gamey
   const [botId, setBotId] = useState("random_bot");
-  const [strategy, setStrategy] = useState('random_bot');
   const [size, setSize] = useState('5');
   // Modo de juego seleccionado en el lobby: 'bot' para jugar contra IA, 'pvp' para dos jugadores locales
   const [gameMode, setGameMode] = useState<'bot' | 'pvp'>('bot');
@@ -46,9 +45,8 @@ const GamePage: React.FC<GamePageProps> = ({ user }) => {
     return () => clearInterval(interval);
   }, []);
 
-  // Inicia la partida guardando la estrategia actual y cambiando de vista
+  // Inicia la partida cambiando de vista
   const handleStartGame = () => {
-      setBotId(strategy);
       setPlayGame(true);
   };
 
@@ -66,7 +64,8 @@ const GamePage: React.FC<GamePageProps> = ({ user }) => {
 
   // Renderizado condicional: Prioridad 1 - La pantalla de juego
   if (playGame) {
-      return <PlayPage botId={botId} user={user} boardSize={Number(size)} gameMode={gameMode} player2Name={effectivePlayer2Name} onBackToLobby={handleBackToLobby}/>;
+      return <PlayPage botId={botId} user={user} boardSize={Number(size)} gameMode={gameMode} player2Name={effectivePlayer2Name} onBackToLobby={handleBackToLobby}
+                onChangeDifficulty={(botId: string) => setBotId(botId)}/>;
   }
 
   // Renderizado condicional: Prioridad 2 - La pantalla de estadísticas
@@ -117,7 +116,7 @@ const GamePage: React.FC<GamePageProps> = ({ user }) => {
 
           {/* Selector de dificultad: solo se muestra en modo bot, ya que en PvP no hay IA */}
           {gameMode === 'bot' && (
-            <select value={strategy} onChange={(e) => setStrategy(e.target.value)} id="botSelect" className="lobby-select">
+            <select value={botId} onChange={(e) => setBotId(e.target.value)} id="botSelect" className="lobby-select">
               <option value="random">Bot Aleatorio (Fácil)</option>
               <option value="mediumbot">Bot Medio (Medio)</option>
               <option value="bridgebot">Bot Puente (Difícil)</option>

--- a/webapp/src/pages/PlayPage.tsx
+++ b/webapp/src/pages/PlayPage.tsx
@@ -5,11 +5,6 @@ import type { User } from "../types/user";
 // Dificultades de los bots
 type DifficultyLevel = 'easy' | 'medium' | 'hard';
 
-const urlToDifficulty: Record<string, DifficultyLevel> = {
-  'random_bot': 'easy',
-  'mediumbot': 'medium',
-  'bridgebot': 'hard',
-};
 
 type PlayPageProps = {
     user: User;
@@ -20,12 +15,13 @@ type PlayPageProps = {
     // Nombre del segundo jugador en modo PvP (por defecto 'Invitado' si se dejó vacío en el lobby)
     player2Name: string;
     onBackToLobby: any;
+    onChangeDifficulty: any;
 };
 
-const PlayPage = ({ user, botId, boardSize, gameMode, player2Name, onBackToLobby }: PlayPageProps) => {
+const PlayPage = ({ user, botId, boardSize, gameMode, player2Name, onBackToLobby, onChangeDifficulty }: PlayPageProps) => {
   // Inicializa basándose en botId recibido como prop
-  const initialDifficulty = urlToDifficulty[botId] || 'easy';
-  const [difficulty, setDifficulty] = useState<DifficultyLevel>(initialDifficulty);
+  const initialDifficulty = botId || 'random_bot';
+  const [difficulty, setDifficulty] = useState<string>(initialDifficulty);
   const [gameKey, setGameKey] = useState(0);
 
   const handleAbandon = async () => {
@@ -37,6 +33,7 @@ const PlayPage = ({ user, botId, boardSize, gameMode, player2Name, onBackToLobby
     const newDifficulty = event.target.value as DifficultyLevel;
     setDifficulty(newDifficulty);
     setGameKey(prev => prev + 1);
+    onChangeDifficulty(newDifficulty);
   };
 
   return (
@@ -64,9 +61,9 @@ const PlayPage = ({ user, botId, boardSize, gameMode, player2Name, onBackToLobby
                 fontWeight: 'bold',
               }}
             >
-              <option value="easy">Dificultad: Fácil</option>
-              <option value="medium">Dificultad: Medio</option>
-              <option value="hard">Dificultad: Difícil</option>
+              <option value="random_bot">Dificultad: Fácil</option>
+              <option value="mediumbot">Dificultad: Medio</option>
+              <option value="bridgebot">Dificultad: Difícil</option>
             </select>
           )}
 
@@ -97,7 +94,7 @@ const PlayPage = ({ user, botId, boardSize, gameMode, player2Name, onBackToLobby
         borderRadius: '12px',
         boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)'
       }}>
-        <Board botId={botId} difficulty={difficulty} boardSize={boardSize} gameMode={gameMode} player1Name={user.nom_usuario || 'Jugador 1'} player2Name={player2Name}/>
+        <Board botId={botId} boardSize={boardSize} gameMode={gameMode} player1Name={user.nom_usuario || 'Jugador 1'} player2Name={player2Name}/>
       </div>
 
         <div>


### PR DESCRIPTION
Se arregla el desplegable de dificultad. Además, se elimina el prop dificultad que en realidad es redundante con botId ya que en nuestra aplicación asociamos la dificultad con los bots y no hay distinción.

También se actualizan los tests asociados que usaban el prop difficulty.