### PR TITLE
users: no recrear tabla en cada arranque de MySQL #196

### DIFF
--- a/users/users-service.js
+++ b/users/users-service.js
@@ -149,7 +149,7 @@ const conectarDB = async () => {
             console.log('Conexión a MySQL establecida correctamente.');
 
             // Sincroniza las tablas (force: true las recrea de forma forzosa)
-            await sequelize.sync({ force: true });
+            await sequelize.sync({ alter: true });
             console.log('Tablas de YOVI listas.');
 
             break;


### PR DESCRIPTION
Antes las tablas se recreaban en cada arranque de MySQL, ahora solo se realizan los cambios necesarios para actualizar el modelo.