### PR TITLE
Bots adicionales para cada dificultad

### DIFF
--- a/gamey/src/bot/bot_helper.rs
+++ b/gamey/src/bot/bot_helper.rs
@@ -13,7 +13,7 @@ pub struct GameData<'a> {
 
 // Devuelve la información básica de la partida asociada al tablero, de tipo Option<GameData>.
 // Si no se puede obtener esta información parcial o totalmente, devuelve None.
-pub fn get_basic_game_data(board: &GameY) -> Option<GameData> {
+pub fn get_basic_game_data(board: &GameY) -> Option<GameData<'_>> {
 
     // 1) Obtener celdas libres
     let available_cells = board.available_cells();

--- a/gamey/src/bot/bot_helper.rs
+++ b/gamey/src/bot/bot_helper.rs
@@ -1,0 +1,43 @@
+/// Clase de utilidad para funciones relacionadas con la programación de los bots.
+use crate::core::{Coordinates, PlayerId, GameY};
+
+// Estructura de datos que contiene información básica común relativa a una partida.
+pub struct GameData<'a> {
+    // Vector con los índices de las celdas disponibles.
+    pub available_cells:  &'a Vec<u32>,
+    // Vector con las coordenadas de las celdas rivales.
+    pub rival_cells: Vec<Coordinates>,
+    // ID del bot durante la partida.
+    pub player_bot_id: PlayerId
+}
+
+// Devuelve la información básica de la partida asociada al tablero, de tipo Option<GameData>.
+// Si no se puede obtener esta información parcial o totalmente, devuelve None.
+pub fn get_basic_game_data(board: &GameY) -> Option<GameData> {
+
+    // 1) Obtener celdas libres
+    let available_cells = board.available_cells();
+    if available_cells.is_empty() {
+        return None;
+    }
+
+    // 2) Obtener el ID de jugador del bot
+    let board_size = board.board_size();
+    let our_player_id = match board.next_player() {
+        Some(id) => id,
+        None => return None,
+    };
+
+    // 3) Obtener las celdas del rival
+    let mut rival_cells = Vec::new();
+    for idx in 0..board.total_cells() {
+        let coords = Coordinates::from_index(idx, board_size);
+        if let Some(player_id) = board.player_at(&coords) {
+            if player_id != our_player_id {
+                rival_cells.push(coords);
+            } 
+        }
+    }
+
+    return Some(GameData {available_cells, rival_cells, player_bot_id: our_player_id});
+}

--- a/gamey/src/bot/bridgebot.rs
+++ b/gamey/src/bot/bridgebot.rs
@@ -1,6 +1,6 @@
-use crate::core::{Coordinates, GameStatus, GameY, Movement};
+use crate::core::{Coordinates, GameStatus, GameY, PlayerId, Movement};
 use crate::YBot;
-use rand::prelude::IndexedRandom;
+use rand::prelude::*;
 
 // BridgeBot aplica una estrategia por prioridades estrictas.
 // 1) Victoria inmediata.
@@ -9,7 +9,17 @@ use rand::prelude::IndexedRandom;
 //    Modo saltos hasta tocar las 3 paredes.
 //    Modo rellenar puentes cuando ya tocó las 3 paredes.
 #[derive(Debug, Default)]
-pub struct BridgeBot;
+pub struct BridgeBot {
+    // Si se habilita, el bot no priorizará tanto el reparar puentes cortados
+    lax_repair: bool
+}
+
+impl BridgeBot {
+    // Devuelve una instancia de BridgeBot con la variante de reparación de puentes laxa
+    pub fn lax_repair_mode() -> BridgeBot {
+        Self {lax_repair: true}
+    }
+}
 
 // Distancia hexagonal entre dos celdas del tablero.
 // Distancia 1 = adyacente, distancia 2 = salto de puente.
@@ -168,12 +178,56 @@ fn immediate_winning_moves(board: &GameY, player: crate::PlayerId, available: &[
         .collect()
 }
 
+fn calculate_bridge_repairs(my_pieces: &Vec<Coordinates>, available_coords: &Vec<Coordinates>, bridge_repairs: &mut Vec<Coordinates>, board: &GameY, enemy_id: PlayerId) {
+    let board_size = board.board_size();
+    for i in 0..my_pieces.len() {
+        for j in (i + 1)..my_pieces.len() {
+            let p1 = my_pieces[i];
+            let p2 = my_pieces[j];
+            // Un "puente" solo se analiza entre piezas a distancia exacta 2.
+            if hex_distance(&p1, &p2) != 2 {
+                continue;
+            }
+
+            let mut free_intermediates = Vec::new();
+            let mut enemy_blocks = 0;
+            for cell in available_coords {
+                if hex_distance(&p1, cell) == 1 && hex_distance(cell, &p2) == 1 {
+                    free_intermediates.push(*cell);
+                }
+            }
+
+            // Revisamos la(s) intermedia(s) ocupada(s): solo cuenta como amenaza si la ocupa el rival.
+            for idx in 0..board.total_cells() {
+                let cell = Coordinates::from_index(idx, board_size);
+                if hex_distance(&p1, &cell) == 1
+                    && hex_distance(&cell, &p2) == 1
+                    && !free_intermediates.contains(&cell)
+                    && board.player_at(&cell) == Some(enemy_id)
+                {
+                    enemy_blocks += 1;
+                }
+            }
+
+            // Reparar solo si queda una única intermedia libre y la otra está tomada por el rival.
+            if free_intermediates.len() == 1 && enemy_blocks > 0 {
+                bridge_repairs.push(free_intermediates[0]);
+            }
+        }
+    }
+}
+
 impl YBot for BridgeBot {
     fn name(&self) -> &str {
+        if self.lax_repair {
+            return "bridgebot_lax";
+        }
         "bridgebot"
     }
 
     fn choose_move(&self, board: &GameY) -> Option<Coordinates> {
+        let mut rng = rand::rng();
+
         // Recolectamos celdas libres en formato índice y validamos salida rápida.
         let available_cells = board.available_cells();
         if available_cells.is_empty() {
@@ -233,40 +287,8 @@ impl YBot for BridgeBot {
 
         // Prioridad 3: reparar puentes cortados con una sola intermedia libre.
         let mut bridge_repairs = Vec::new();
-        for i in 0..my_pieces.len() {
-            for j in (i + 1)..my_pieces.len() {
-                let p1 = my_pieces[i];
-                let p2 = my_pieces[j];
-                // Un "puente" solo se analiza entre piezas a distancia exacta 2.
-                if hex_distance(&p1, &p2) != 2 {
-                    continue;
-                }
-
-                let mut free_intermediates = Vec::new();
-                let mut enemy_blocks = 0;
-                for cell in &available_coords {
-                    if hex_distance(&p1, cell) == 1 && hex_distance(cell, &p2) == 1 {
-                        free_intermediates.push(*cell);
-                    }
-                }
-
-                // Revisamos la(s) intermedia(s) ocupada(s): solo cuenta como amenaza si la ocupa el rival.
-                for idx in 0..board.total_cells() {
-                    let cell = Coordinates::from_index(idx, board_size);
-                    if hex_distance(&p1, &cell) == 1
-                        && hex_distance(&cell, &p2) == 1
-                        && !free_intermediates.contains(&cell)
-                        && board.player_at(&cell) == Some(enemy_id)
-                    {
-                        enemy_blocks += 1;
-                    }
-                }
-
-                // Reparar solo si queda una única intermedia libre y la otra está tomada por el rival.
-                if free_intermediates.len() == 1 && enemy_blocks > 0 {
-                    bridge_repairs.push(free_intermediates[0]);
-                }
-            }
+        if !self.lax_repair || (self.lax_repair && rng.random::<bool>()) {
+            calculate_bridge_repairs(&my_pieces, &available_coords, &mut bridge_repairs, board, enemy_id);
         }
         if !bridge_repairs.is_empty() {
             return pick_best_with_tie_break(bridge_repairs, board_size);
@@ -450,13 +472,13 @@ mod tests {
     #[test]
     // Verificamos que el bot se identifica correctamente.
     fn test_bridgebot_identity() {
-        assert_eq!(BridgeBot.name(), "bridgebot");
+        assert_eq!(BridgeBot::default().name(), "bridgebot");
     }
 
     #[test]
     // En la apertura, el bot debería elegir una de las posiciones centrales para maximizar flexibilidad.
     fn test_first_move_is_always_center() {
-        let bot = BridgeBot;
+        let bot = BridgeBot::default();
         let game = GameY::new(5);
         let chosen = bot.choose_move(&game).expect("Debe mover");
         let valid_centers = [4, 7, 8];
@@ -466,7 +488,7 @@ mod tests {
     #[test]
     // El bot no debería intentar mover en un tablero lleno, debe retornar None.
     fn test_handles_full_board_gracefully() {
-        let bot = BridgeBot;
+        let bot = BridgeBot::default();
         let board_map = "
              0
             1 0
@@ -482,7 +504,7 @@ mod tests {
     #[test]
     // El Jugador (1) tiene una jugada ganadora inmediata en el índice 10 (hay que bloquearla).
     fn test_priority_block_enemy_win() {
-        let bot = BridgeBot;
+        let bot = BridgeBot::default();
         let board_map = "
             1
            1 .
@@ -499,7 +521,7 @@ mod tests {
     #[test]
     // El Bot (0) tiene una jugada ganadora inmediata en el índice 10.
     fn test_priority_immediate_win_for_bot() {
-        let bot = BridgeBot;
+        let bot = BridgeBot::default();
         let board_map = "
             0
            0 .
@@ -519,7 +541,7 @@ mod tests {
     #[test]
     // En una situación donde tanto el bot como el enemigo tienen jugadas ganadoras inmediatas, el bot debe priorizar su victoria.
     fn test_priority_level_1_over_level_2() {
-        let bot = BridgeBot;
+        let bot = BridgeBot::default();
         let board_map = "
             0
            0 .
@@ -542,7 +564,7 @@ mod tests {
     #[test]
     // El Bot (0) tiene un puente cortado por el rival (1) con una sola intermedia libre. Debería no reparar ese puente (inutil).
     fn test_intelligent_ignoring_useless_bridges() {
-        let bot = BridgeBot;
+        let bot = BridgeBot::default();
         // El Bot (0) ya tiene una estructura sólida arriba.
         // Un puente abajo (cerca del índice 8) no aporta nada a su victoria.
         let board_map = "
@@ -561,7 +583,7 @@ mod tests {
     #[test]
     // El Bot (0) debería saltar a distancia 2 hacia un borde libre para expandir su red, en lugar de jugar adyacente.
     fn test_expansion_via_safe_jumps() {
-        let bot = BridgeBot;
+        let bot = BridgeBot::default();
         let board_map = "
             1
            . 1
@@ -585,7 +607,7 @@ mod tests {
     // El Bot (0) tiene un puente cortado por el rival (1) con una sola intermedia libre. Debería reparar ese puente para no perderlo.
     fn test_compromised_bridge() {
         // Puente comprometido
-        let bot = BridgeBot;
+        let bot = BridgeBot::default();
         let board_map = "
             .
            . 0
@@ -608,7 +630,7 @@ mod tests {
     #[test]
     // Si el bloqueador del puente es una ficha propia, el bot no debería intentar "reparar" ese puente, ya que no está realmente comprometido.
     fn test_does_not_repair_bridge_if_block_is_own_piece() {
-        let bot = BridgeBot;
+        let bot = BridgeBot::default();
         let board_map = "
             .
            . 0
@@ -632,7 +654,7 @@ mod tests {
     #[test]
     // Bajo presión de un puente cortado, el bot debería optar por un movimiento de avance hacia la pared faltante, incluso si no es un salto, para no perder progreso.
     fn test_improvised_wall_bridge_when_under_pressure() {
-        let bot = BridgeBot;
+        let bot = BridgeBot::default();
         let board_map = "
             1
            1 1
@@ -672,5 +694,13 @@ mod tests {
             "FALLO: En empate por puntuación y centralidad, debe elegir menor índice"
         );
     }
+
+    #[test]
+    // Inicializar bot con variante laxa
+    fn test_initialize_lax_mode() {
+        let bot = BridgeBot::lax_repair_mode();
+        assert!(bot.lax_repair);
+    }
+
 
 }

--- a/gamey/src/bot/lapabot.rs
+++ b/gamey/src/bot/lapabot.rs
@@ -1,0 +1,243 @@
+use crate::core::{Coordinates, GameY, PlayerId};
+use crate::YBot;
+use rand::prelude::IndexedRandom;
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+/// Bot "lapa": bot medio
+/// Este bot siempre intenta colocar su ficha pegada a una ficha del rival.
+/// Prioriza colocar sus fichas al lado de fichas rivales que tengan el menor número de fichas suyas
+/// adyacentes, así que primero colocará al lado de fichas del rival sin nada alrededor.
+#[derive(Debug, Default)]
+pub struct LapaBot;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+struct WeightedCell {
+    coords: Coordinates,
+    player_id: PlayerId,
+    weight: u32
+} 
+
+impl WeightedCell {
+    fn new(coords:Coordinates, player_id: PlayerId, weight: u32) -> WeightedCell {
+        WeightedCell {coords, player_id, weight}
+    }
+}
+
+impl Ord for WeightedCell {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.weight.cmp(&other.weight)
+    }
+}
+
+impl PartialOrd for WeightedCell {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+
+impl YBot for LapaBot {
+    fn name(&self) -> &str {
+        "lapabot"
+    }
+
+    fn choose_move(&self, board: &GameY) -> Option<Coordinates> {
+        // 1) Obtener celdas libres
+        let available_cells = board.available_cells();
+        if available_cells.is_empty() {
+            return None;
+        }
+
+
+        // 2) Obtener el ID de jugador del bot
+        let board_size = board.board_size();
+        let our_player_id = match board.next_player() {
+            Some(id) => id,
+            None => return None,
+        };
+
+        // 3) Obtener las celdas del rival
+        let mut rival_cells = Vec::new();
+        for idx in 0..board.total_cells() {
+            let coords = Coordinates::from_index(idx, board_size);
+            if let Some(player_id) = board.player_at(&coords) {
+                if player_id != our_player_id {
+                    rival_cells.push(coords);
+                } 
+            }
+        }
+
+        // 4) Puntuar las celdas del rival según el algoritmo descrito en weight_cell
+        // y ordenarlas de más prioritarias a menos (más peso, más prioritaria)
+        let mut heap = BinaryHeap::new();
+        for rival_cell in rival_cells {
+            let weighted_cell = weight_cell(rival_cell, board, our_player_id);
+            heap.push(weighted_cell);
+        }
+
+        // 5) Buscamos la celda rival con más puntuación y que tenga alguna celda adyacente libre.
+        // Si no existe ninguna, se hace un movimiento aleatorio.
+        for rival_cell in heap {
+            let adjacent_coords = rival_cell.coords.get_adjacent_coords();
+            // Elegimos la primera celda adyacente libre que encontremos
+            let adjacent_free_cell = adjacent_coords.iter().find(|&coord| board.player_at(coord).is_none());
+            if let Some(adjacent_free_cords) = adjacent_free_cell {
+                return Some(adjacent_free_cords.to_owned());
+            }
+        }
+
+        // Si no se encontró ninguna celda adyacente libre, elegir una aleatoria
+        let cell = available_cells.choose(&mut rand::rng())?;
+        let coordinates = Coordinates::from_index(*cell, board.board_size());
+        Some(coordinates)
+    }
+}
+
+// Devuelve el peso de una celda para el algoritmo de LapaBot en una estructura
+// WeightedCell.
+// El algoritmo de peso es el siguiente:
+// Obtener todas las celdas adyacentes válidas
+// Empezar con un peso base de 1000 puntos, y restar 50 por cada casilla adyacente colocada por
+// nosotros.
+// A mayor peso, mejor casilla.
+fn weight_cell(cell: Coordinates, board: &GameY, id: PlayerId) -> WeightedCell {
+    let our_id = id;
+    // Obtener todas las celdas adyacentes válidas
+    // Empezamos con una base de 1000 puntos, y restamos 50 por cada casilla adyacente nuestra.
+    let mut weight = 1000;
+    let adjancet_cells = cell.get_adjacent_coords();
+    for cell in adjancet_cells {
+        if let Some(id) = board.player_at(&cell) {
+            if id == our_id {
+                weight -= 50;
+            }
+        }
+
+    }
+
+    WeightedCell::new(cell,id,weight)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{Movement, PlayerId};
+
+    #[test]
+    fn test_bot_name() {
+        let bot = LapaBot;
+        assert_eq!(bot.name(), "lapabot");
+    }
+
+    #[test]
+    fn test_bot_returns_move_on_empty_board() {
+        let bot = LapaBot;
+        let game = GameY::new(5);
+
+        let chosen_move = bot.choose_move(&game);
+        assert!(chosen_move.is_some());
+    }
+
+    #[test]
+    fn test_bot_returns_valid_coordinates() {
+        let bot = LapaBot;
+        let game = GameY::new(5);
+
+        let coords = bot.choose_move(&game).unwrap();
+        let index = coords.to_index(game.board_size());
+
+        // Index should be within the valid range for a size-5 board
+        // Total cells = (5 * 6) / 2 = 15
+        assert!(index < 15);
+    }
+
+    #[test]
+    fn test_bot_returns_none_on_full_board() {
+        let bot = LapaBot;
+        let mut game = GameY::new(2);
+
+        // Fill the board (size 2 has 3 cells)
+        let moves = vec![
+            Movement::Placement {
+                player: PlayerId::new(0),
+                coords: Coordinates::new(1, 0, 0),
+            },
+            Movement::Placement {
+                player: PlayerId::new(1),
+                coords: Coordinates::new(0, 1, 0),
+            },
+            Movement::Placement {
+                player: PlayerId::new(0),
+                coords: Coordinates::new(0, 0, 1),
+            },
+        ];
+
+        for mv in moves {
+            game.add_move(mv).unwrap();
+        }
+
+        // Board is now full
+        assert!(game.available_cells().is_empty());
+        let chosen_move = bot.choose_move(&game);
+        assert!(chosen_move.is_none());
+    }
+
+    #[test]
+    fn test_bot_chooses_from_available_cells() {
+        let bot = LapaBot;
+        let mut game = GameY::new(3);
+
+        // Make some moves to reduce available cells
+        game.add_move(Movement::Placement {
+            player: PlayerId::new(0),
+            coords: Coordinates::new(2, 0, 0),
+        })
+        .unwrap();
+
+        let coords = bot.choose_move(&game).unwrap();
+        let index = coords.to_index(game.board_size());
+
+        // The chosen index should be in the available cells
+        assert!(game.available_cells().contains(&index));
+        // The chosen coords should be next to the player coordinates
+        assert_eq!(coords.x(), 1);
+        assert_eq!(coords.y(), 0);
+        assert_eq!(coords.z(), 1);
+    }
+
+    #[test]
+    fn test_bot_multiple_calls_return_valid_moves() {
+        let bot = LapaBot;
+        let game = GameY::new(7);
+
+        for _ in 0..10 {
+            let coords = bot.choose_move(&game).unwrap();
+            let index = coords.to_index(game.board_size());
+
+            assert!(index < 28);
+            assert!(game.available_cells().contains(&index));
+        }
+    }
+
+    #[test]
+    fn test_weighted_cell_creation() {
+        let weighted_cell  = WeightedCell::new(Coordinates::new(1,2,3), PlayerId::new(0), 25);
+        assert_eq!(weighted_cell.coords.x(), 1);
+        assert_eq!(weighted_cell.coords.y(), 2);
+        assert_eq!(weighted_cell.coords.z(), 3);
+        assert_eq!(weighted_cell.player_id, PlayerId::new(0));
+        assert_eq!(weighted_cell.weight, 25);
+    }
+
+    #[test]
+    fn test_weighted_cell_comparison() {
+        let weighted_cell1  = WeightedCell::new(Coordinates::new(1,2,3), PlayerId::new(0), 25);
+        let weighted_cell2  = WeightedCell::new(Coordinates::new(1,2,3), PlayerId::new(0), 50);
+        assert_eq!(weighted_cell1.cmp(&weighted_cell2), Ordering::Less);
+        assert_eq!(weighted_cell2.cmp(&weighted_cell1), Ordering::Greater);
+    }
+    
+}

--- a/gamey/src/bot/lapabot.rs
+++ b/gamey/src/bot/lapabot.rs
@@ -1,4 +1,5 @@
 use crate::core::{Coordinates, GameY, PlayerId};
+use crate::bot::bot_helper;
 use crate::YBot;
 use rand::prelude::IndexedRandom;
 
@@ -44,30 +45,14 @@ impl YBot for LapaBot {
     }
 
     fn choose_move(&self, board: &GameY) -> Option<Coordinates> {
-        // 1) Obtener celdas libres
-        let available_cells = board.available_cells();
-        if available_cells.is_empty() {
-            return None;
-        }
-
-
-        // 2) Obtener el ID de jugador del bot
-        let board_size = board.board_size();
-        let our_player_id = match board.next_player() {
-            Some(id) => id,
-            None => return None,
+        let game_data = match bot_helper::get_basic_game_data(board) {
+            Some(data) => data,
+            None => return None
         };
 
-        // 3) Obtener las celdas del rival
-        let mut rival_cells = Vec::new();
-        for idx in 0..board.total_cells() {
-            let coords = Coordinates::from_index(idx, board_size);
-            if let Some(player_id) = board.player_at(&coords) {
-                if player_id != our_player_id {
-                    rival_cells.push(coords);
-                } 
-            }
-        }
+        let available_cells = game_data.available_cells;
+        let rival_cells = game_data.rival_cells;
+        let our_player_id = game_data.player_bot_id;
 
         // 4) Puntuar las celdas del rival según el algoritmo descrito en weight_cell
         // y ordenarlas de más prioritarias a menos (más peso, más prioritaria)

--- a/gamey/src/bot/lapabot.rs
+++ b/gamey/src/bot/lapabot.rs
@@ -80,7 +80,7 @@ impl YBot for LapaBot {
         // 5) Buscamos la celda rival con más puntuación y que tenga alguna celda adyacente libre.
         // Si no existe ninguna, se hace un movimiento aleatorio.
         for rival_cell in heap {
-            let adjacent_coords = rival_cell.coords.get_adjacent_coords();
+            let adjacent_coords = board.get_neighbors(&rival_cell.coords);
             // Elegimos la primera celda adyacente libre que encontremos
             let adjacent_free_cell = adjacent_coords.iter().find(|&coord| board.player_at(coord).is_none());
             if let Some(adjacent_free_cords) = adjacent_free_cell {
@@ -107,7 +107,7 @@ fn weight_cell(cell: Coordinates, board: &GameY, id: PlayerId) -> WeightedCell {
     // Obtener todas las celdas adyacentes válidas
     // Empezamos con una base de 1000 puntos, y restamos 50 por cada casilla adyacente nuestra.
     let mut weight = 1000;
-    let adjancet_cells = cell.get_adjacent_coords();
+    let adjancet_cells =  board.get_neighbors(&cell);
     for cell in adjancet_cells {
         if let Some(id) = board.player_at(&cell) {
             if id == our_id {
@@ -204,8 +204,8 @@ mod tests {
         assert!(game.available_cells().contains(&index));
         // The chosen coords should be next to the player coordinates
         assert_eq!(coords.x(), 1);
-        assert_eq!(coords.y(), 0);
-        assert_eq!(coords.z(), 1);
+        assert_eq!(coords.y(), 1);
+        assert_eq!(coords.z(), 0);
     }
 
     #[test]

--- a/gamey/src/bot/mirrorbot.rs
+++ b/gamey/src/bot/mirrorbot.rs
@@ -1,0 +1,168 @@
+use crate::core::{Coordinates, GameY};
+use crate::YBot;
+use rand::prelude::IndexedRandom;
+
+/// Bot "espejo": bot fácil
+/// Este bot intenta llenar el tablero espejando los movimientos del rival.
+/// Si no hay ningún movimiento espejable, realiza un movimiento aleatorio.
+#[derive(Debug, Default)]
+pub struct MirrorBot;
+
+
+impl YBot for MirrorBot {
+    fn name(&self) -> &str {
+        "mirrorbot"
+    }
+
+    fn choose_move(&self, board: &GameY) -> Option<Coordinates> {
+        // 1) Obtener celdas libres
+        let available_cells = board.available_cells();
+        if available_cells.is_empty() {
+            return None;
+        }
+
+
+        // 2) Obtener el ID de jugador del bot
+        let board_size = board.board_size();
+        let our_player_id = match board.next_player() {
+            Some(id) => id,
+            None => return None,
+        };
+
+        // 3) Obtener las celdas del rival
+        let mut rival_cells = Vec::new();
+        for idx in 0..board.total_cells() {
+            let coords = Coordinates::from_index(idx, board_size);
+            if let Some(player_id) = board.player_at(&coords) {
+                if player_id != our_player_id {
+                    rival_cells.push(coords);
+                } 
+            }
+        }
+
+        // 4) Recorrer las celdas rivales y guardar las que no estén espejadas.
+        let mut non_mirrored_cells = Vec::new();
+        for rival_cell in rival_cells {
+            let mirrored_coords = rival_cell.get_mirrored_coords();
+            if board.player_at(&mirrored_coords).is_none() {
+                non_mirrored_cells.push(mirrored_coords);
+            }
+        }
+
+        // 5) Espejamos la primera celda que no esté espejada.
+        // En caso de que no existan celdas sin espejar, realiza movimiento aleatorio.
+        
+        for cell in non_mirrored_cells {
+            return Some(cell);
+        }
+
+        // Si no se encontró ninguna celda adyacente libre (que no debería ser el caso), elegir una aleatoria
+        let cell = available_cells.choose(&mut rand::rng())?;
+        let coordinates = Coordinates::from_index(*cell, board.board_size());
+        Some(coordinates)
+    }
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{Movement, PlayerId};
+
+    #[test]
+    fn test_bot_name() {
+        let bot = MirrorBot;
+        assert_eq!(bot.name(), "mirrorbot");
+    }
+
+    #[test]
+    fn test_bot_returns_move_on_empty_board() {
+        let bot = MirrorBot;
+        let game = GameY::new(5);
+
+        let chosen_move = bot.choose_move(&game);
+        assert!(chosen_move.is_some());
+    }
+
+    #[test]
+    fn test_bot_returns_valid_coordinates() {
+        let bot = MirrorBot;
+        let game = GameY::new(5);
+
+        let coords = bot.choose_move(&game).unwrap();
+        let index = coords.to_index(game.board_size());
+
+        // Index should be within the valid range for a size-5 board
+        // Total cells = (5 * 6) / 2 = 15
+        assert!(index < 15);
+    }
+
+    #[test]
+    fn test_bot_returns_none_on_full_board() {
+        let bot = MirrorBot;
+        let mut game = GameY::new(2);
+
+        // Fill the board (size 2 has 3 cells)
+        let moves = vec![
+            Movement::Placement {
+                player: PlayerId::new(0),
+                coords: Coordinates::new(1, 0, 0),
+            },
+            Movement::Placement {
+                player: PlayerId::new(1),
+                coords: Coordinates::new(0, 1, 0),
+            },
+            Movement::Placement {
+                player: PlayerId::new(0),
+                coords: Coordinates::new(0, 0, 1),
+            },
+        ];
+
+        for mv in moves {
+            game.add_move(mv).unwrap();
+        }
+
+        // Board is now full
+        assert!(game.available_cells().is_empty());
+        let chosen_move = bot.choose_move(&game);
+        assert!(chosen_move.is_none());
+    }
+
+    #[test]
+    fn test_bot_chooses_from_available_cells() {
+        let bot = MirrorBot;
+        let mut game = GameY::new(5);
+
+        // Make some moves to reduce available cells
+        game.add_move(Movement::Placement {
+            player: PlayerId::new(0),
+            coords: Coordinates::new(2, 2, 0),
+        })
+        .unwrap();
+
+        let coords = bot.choose_move(&game).unwrap();
+        let index = coords.to_index(game.board_size());
+
+        // The chosen index should be in the available cells
+        assert!(game.available_cells().contains(&index));
+        // The chosen coords should be the mirrored coords
+        assert_eq!(coords.x(), 2);
+        assert_eq!(coords.y(), 0);
+        assert_eq!(coords.z(), 2);
+    }
+
+    #[test]
+    fn test_bot_multiple_calls_return_valid_moves() {
+        let bot = MirrorBot;
+        let game = GameY::new(7);
+
+        for _ in 0..10 {
+            let coords = bot.choose_move(&game).unwrap();
+            let index = coords.to_index(game.board_size());
+
+            assert!(index < 28);
+            assert!(game.available_cells().contains(&index));
+        }
+    }
+}

--- a/gamey/src/bot/mirrorbot.rs
+++ b/gamey/src/bot/mirrorbot.rs
@@ -1,4 +1,5 @@
 use crate::core::{Coordinates, GameY};
+use crate::bot::bot_helper;
 use crate::YBot;
 use rand::prelude::IndexedRandom;
 
@@ -15,30 +16,13 @@ impl YBot for MirrorBot {
     }
 
     fn choose_move(&self, board: &GameY) -> Option<Coordinates> {
-        // 1) Obtener celdas libres
-        let available_cells = board.available_cells();
-        if available_cells.is_empty() {
-            return None;
-        }
-
-
-        // 2) Obtener el ID de jugador del bot
-        let board_size = board.board_size();
-        let our_player_id = match board.next_player() {
-            Some(id) => id,
-            None => return None,
+        let game_data = match bot_helper::get_basic_game_data(board) {
+            Some(data) => data,
+            None => return None
         };
 
-        // 3) Obtener las celdas del rival
-        let mut rival_cells = Vec::new();
-        for idx in 0..board.total_cells() {
-            let coords = Coordinates::from_index(idx, board_size);
-            if let Some(player_id) = board.player_at(&coords) {
-                if player_id != our_player_id {
-                    rival_cells.push(coords);
-                } 
-            }
-        }
+        let available_cells = game_data.available_cells;
+        let rival_cells = game_data.rival_cells;
 
         // 4) Recorrer las celdas rivales y guardar las que no estén espejadas.
         let mut non_mirrored_cells = Vec::new();

--- a/gamey/src/bot/mod.rs
+++ b/gamey/src/bot/mod.rs
@@ -9,12 +9,14 @@
 
 pub mod bridgebot;
 pub mod mediumbot;
+pub mod mirrorbot;
 pub mod lapabot;
 pub mod random;
 pub mod ybot;
 pub mod ybot_registry;
 pub use bridgebot::*;
 pub use mediumbot::*;
+pub use mirrorbot::*;
 pub use lapabot::*;
 pub use random::*;
 pub use ybot::*;

--- a/gamey/src/bot/mod.rs
+++ b/gamey/src/bot/mod.rs
@@ -9,11 +9,13 @@
 
 pub mod bridgebot;
 pub mod mediumbot;
+pub mod lapabot;
 pub mod random;
 pub mod ybot;
 pub mod ybot_registry;
 pub use bridgebot::*;
 pub use mediumbot::*;
+pub use lapabot::*;
 pub use random::*;
 pub use ybot::*;
 pub use ybot_registry::*;

--- a/gamey/src/bot/mod.rs
+++ b/gamey/src/bot/mod.rs
@@ -7,6 +7,8 @@
 //! - [`YBotRegistry`] - A registry for managing multiple bot implementations
 //! - [`RandomBot`] - A simple bot that makes random valid moves
 
+mod bot_helper;
+
 pub mod bridgebot;
 pub mod mediumbot;
 pub mod mirrorbot;

--- a/gamey/src/bot_server/mod.rs
+++ b/gamey/src/bot_server/mod.rs
@@ -38,7 +38,7 @@ pub use game_status::StatusResponse;
 pub use error::ErrorResponse;
 pub use version::*;
 
-use crate::{GameYError, RandomBot, LapaBot, MediumBot, BridgeBot, YBotRegistry, state::AppState};
+use crate::{GameYError, RandomBot, LapaBot, MirrorBot, MediumBot, BridgeBot, YBotRegistry, state::AppState};
 
 /// Creates the Axum router with the given state.
 ///
@@ -101,6 +101,7 @@ pub fn create_default_state() -> AppState {
         .with_bot(Arc::new(RandomBot))
         .with_bot(Arc::new(LapaBot::default()))
         .with_bot(Arc::new(MediumBot::default()))
+        .with_bot(Arc::new(MirrorBot::default()))
         .with_bot(Arc::new(BridgeBot::default()));
     AppState::new(bots)
 }

--- a/gamey/src/bot_server/mod.rs
+++ b/gamey/src/bot_server/mod.rs
@@ -38,7 +38,7 @@ pub use game_status::StatusResponse;
 pub use error::ErrorResponse;
 pub use version::*;
 
-use crate::{GameYError, RandomBot, MediumBot, BridgeBot, YBotRegistry, state::AppState};
+use crate::{GameYError, RandomBot, LapaBot, MediumBot, BridgeBot, YBotRegistry, state::AppState};
 
 /// Creates the Axum router with the given state.
 ///
@@ -97,7 +97,11 @@ async fn add_headers_middleware(request: Request, next: Next) -> impl IntoRespon
 ///
 /// The default state includes the `RandomBot` which selects moves randomly.
 pub fn create_default_state() -> AppState {
-    let bots = YBotRegistry::new().with_bot(Arc::new(RandomBot)).with_bot(Arc::new(MediumBot::default())).with_bot(Arc::new(BridgeBot::default()));
+    let bots = YBotRegistry::new()
+        .with_bot(Arc::new(RandomBot))
+        .with_bot(Arc::new(LapaBot::default()))
+        .with_bot(Arc::new(MediumBot::default()))
+        .with_bot(Arc::new(BridgeBot::default()));
     AppState::new(bots)
 }
 

--- a/gamey/src/bot_server/mod.rs
+++ b/gamey/src/bot_server/mod.rs
@@ -102,7 +102,8 @@ pub fn create_default_state() -> AppState {
         .with_bot(Arc::new(LapaBot::default()))
         .with_bot(Arc::new(MediumBot::default()))
         .with_bot(Arc::new(MirrorBot::default()))
-        .with_bot(Arc::new(BridgeBot::default()));
+        .with_bot(Arc::new(BridgeBot::default()))
+        .with_bot(Arc::new(BridgeBot::lax_repair_mode()));
     AppState::new(bots)
 }
 

--- a/gamey/src/cli.rs
+++ b/gamey/src/cli.rs
@@ -7,7 +7,7 @@
 //! - Server: Run as an HTTP server for bot API
 
 use crate::{
-    Coordinates, GameAction, Movement, RandomBot, MediumBot, BridgeBot, RenderOptions, YBot, YBotRegistry, game,
+    Coordinates, GameAction, Movement, RandomBot, LapaBot, MediumBot, BridgeBot, RenderOptions, YBot, YBotRegistry, game,
 };
 use crate::{GameStatus, GameY, PlayerId};
 use anyhow::Result;
@@ -69,7 +69,11 @@ pub fn run_cli_game() -> Result<()> {
     let args = CliArgs::parse();
     let mut render_options = crate::RenderOptions::default();
     let mut rl = DefaultEditor::new()?;
-    let bots_registry = YBotRegistry::new().with_bot(Arc::new(MediumBot::default())).with_bot(Arc::new(BridgeBot::default())).with_bot(Arc::new(RandomBot));
+    let bots_registry = YBotRegistry::new()
+        .with_bot(Arc::new(LapaBot::default()))
+        .with_bot(Arc::new(MediumBot::default()))
+        .with_bot(Arc::new(BridgeBot::default()))
+        .with_bot(Arc::new(RandomBot));
     let bot: Arc<dyn YBot> = match bots_registry.find(&args.bot) {
         Some(b) => b,
         None => {

--- a/gamey/src/cli.rs
+++ b/gamey/src/cli.rs
@@ -74,6 +74,7 @@ pub fn run_cli_game() -> Result<()> {
         .with_bot(Arc::new(MediumBot::default()))
         .with_bot(Arc::new(MirrorBot::default()))
         .with_bot(Arc::new(BridgeBot::default()))
+        .with_bot(Arc::new(BridgeBot::lax_repair_mode()))
         .with_bot(Arc::new(RandomBot));
     let bot: Arc<dyn YBot> = match bots_registry.find(&args.bot) {
         Some(b) => b,

--- a/gamey/src/cli.rs
+++ b/gamey/src/cli.rs
@@ -7,7 +7,7 @@
 //! - Server: Run as an HTTP server for bot API
 
 use crate::{
-    Coordinates, GameAction, Movement, RandomBot, LapaBot, MediumBot, BridgeBot, RenderOptions, YBot, YBotRegistry, game,
+    Coordinates, GameAction, Movement, RandomBot, LapaBot, MirrorBot, MediumBot, BridgeBot, RenderOptions, YBot, YBotRegistry, game,
 };
 use crate::{GameStatus, GameY, PlayerId};
 use anyhow::Result;
@@ -72,6 +72,7 @@ pub fn run_cli_game() -> Result<()> {
     let bots_registry = YBotRegistry::new()
         .with_bot(Arc::new(LapaBot::default()))
         .with_bot(Arc::new(MediumBot::default()))
+        .with_bot(Arc::new(MirrorBot::default()))
         .with_bot(Arc::new(BridgeBot::default()))
         .with_bot(Arc::new(RandomBot));
     let bot: Arc<dyn YBot> = match bots_registry.find(&args.bot) {

--- a/gamey/src/core/coord.rs
+++ b/gamey/src/core/coord.rs
@@ -99,65 +99,6 @@ impl Coordinates {
         self.z == 0
     }
 
-    // Returns a vector with the coordinates of the adjacent cells of this cell.
-    pub fn get_adjacent_coords(&self) -> Vec<Coordinates> {
-
-        // There are six possible adjacent cells, but depending on where the cell is located, some
-        // adjacent cells might not be available.
-        // For example, the cell on the top of the triangle only has 2 adjacent cells available.
-        // So we make sure that we only generate the available adjacent cells by checking whether
-        // the cell is touching some sides of the triangle or not.
-        let mut add_left_cell = true;
-        let mut add_right_cell = true;
-        let mut add_upper_left_cell = true;
-        let mut add_upper_right_cell = true;
-        let mut add_lower_left_cell = true;
-        let mut add_lower_right_cell = true;
-
-        if self.touches_side_a() {
-            add_lower_left_cell = false;
-            add_lower_right_cell = false;
-        }
-
-        if self.touches_side_b() {
-            add_left_cell = false;
-            add_upper_left_cell = false;
-        }
-
-        if self.touches_side_c() {
-            add_right_cell = false;
-            add_upper_right_cell = false;
-        }
-
-        let mut adjancet_cells = Vec::new();
-        if add_left_cell {
-            let left_cell = Coordinates::new(self.x, self.y-1, self.z+1);
-            adjancet_cells.push(left_cell);
-        }
-        if add_right_cell {
-            let right_cell = Coordinates::new(self.x, self.y+1, self.z-1);
-            adjancet_cells.push(right_cell);
-        }
-        if add_upper_left_cell {
-            let upper_left_cell = Coordinates::new(self.x+1, self.y-1, self.z);
-            adjancet_cells.push(upper_left_cell);
-        }
-        if add_upper_right_cell {
-            let upper_right_cell = Coordinates::new(self.x+1, self.y, self.z-1);
-            adjancet_cells.push(upper_right_cell);
-        }
-        if add_lower_left_cell {
-            let lower_left_cell = Coordinates::new(self.x-1, self.y, self.z+1);
-            adjancet_cells.push(lower_left_cell);
-        }
-        if add_lower_right_cell {
-            let lower_right_cell = Coordinates::new(self.x-1, self.y+1, self.z);
-            adjancet_cells.push(lower_right_cell);
-        }
-
-        adjancet_cells
-    }
-
     // Returns this coords mirrored on the vertical plane. 
     pub fn get_mirrored_coords(&self) -> Coordinates {
         Coordinates::new(self.x, self.z, self.y)
@@ -263,45 +204,6 @@ mod tests {
         assert!(!interior.touches_side_a());
         assert!(!interior.touches_side_b());
         assert!(!interior.touches_side_c());
-    }
-
-    // Generate adjacent coordinates for the case that all adjacent cells are valid
-    #[test]
-    fn test_get_adjacent_coords_all_valid() {
-        let board_size = 5;
-        let coords = Coordinates::from_index(4, board_size);
-        let adjacent_coords = coords.get_adjacent_coords();
-        assert_eq!(adjacent_coords.len(), 6);
-        assert_eq!(adjacent_coords[0].to_index(board_size), 3);
-        assert_eq!(adjacent_coords[1].to_index(board_size), 5);
-        assert_eq!(adjacent_coords[2].to_index(board_size), 1);
-        assert_eq!(adjacent_coords[3].to_index(board_size), 2);
-        assert_eq!(adjacent_coords[4].to_index(board_size), 7);
-        assert_eq!(adjacent_coords[5].to_index(board_size), 8);
-    }
-
-    // Generate adjacent coordinates for the case that it touches side A
-    #[test]
-    fn test_get_adjacent_coords_toches_a() {
-        let board_size = 5;
-        let coords = Coordinates::from_index(12, board_size);
-        let adjacent_coords = coords.get_adjacent_coords();
-        assert_eq!(adjacent_coords.len(), 4);
-        assert_eq!(adjacent_coords[0].to_index(board_size), 11);
-        assert_eq!(adjacent_coords[1].to_index(board_size), 13);
-        assert_eq!(adjacent_coords[2].to_index(board_size), 7);
-        assert_eq!(adjacent_coords[3].to_index(board_size), 8);
-    }
-
-    // Generate adjacent coordinates for the case that it touches side B and C (corner)
-    #[test]
-    fn test_get_adjacent_coords_toches_b_and_c() {
-        let board_size = 5;
-        let coords = Coordinates::from_index(0, board_size);
-        let adjacent_coords = coords.get_adjacent_coords();
-        assert_eq!(adjacent_coords.len(), 2);
-        assert_eq!(adjacent_coords[0].to_index(board_size), 1);
-        assert_eq!(adjacent_coords[1].to_index(board_size), 2);
     }
 
     // Check the mirror of a given coordinate

--- a/gamey/src/core/coord.rs
+++ b/gamey/src/core/coord.rs
@@ -157,6 +157,11 @@ impl Coordinates {
 
         adjancet_cells
     }
+
+    // Returns this coords mirrored on the vertical plane. 
+    pub fn get_mirrored_coords(&self) -> Coordinates {
+        Coordinates::new(self.x, self.z, self.y)
+    }
 }
 
 impl From<Coordinates> for Vec<u32> {
@@ -258,6 +263,68 @@ mod tests {
         assert!(!interior.touches_side_a());
         assert!(!interior.touches_side_b());
         assert!(!interior.touches_side_c());
+    }
+
+    // Generate adjacent coordinates for the case that all adjacent cells are valid
+    #[test]
+    fn test_get_adjacent_coords_all_valid() {
+        let board_size = 5;
+        let coords = Coordinates::from_index(4, board_size);
+        let adjacent_coords = coords.get_adjacent_coords();
+        assert_eq!(adjacent_coords.len(), 6);
+        assert_eq!(adjacent_coords[0].to_index(board_size), 3);
+        assert_eq!(adjacent_coords[1].to_index(board_size), 5);
+        assert_eq!(adjacent_coords[2].to_index(board_size), 1);
+        assert_eq!(adjacent_coords[3].to_index(board_size), 2);
+        assert_eq!(adjacent_coords[4].to_index(board_size), 7);
+        assert_eq!(adjacent_coords[5].to_index(board_size), 8);
+    }
+
+    // Generate adjacent coordinates for the case that it touches side A
+    #[test]
+    fn test_get_adjacent_coords_toches_a() {
+        let board_size = 5;
+        let coords = Coordinates::from_index(12, board_size);
+        let adjacent_coords = coords.get_adjacent_coords();
+        assert_eq!(adjacent_coords.len(), 4);
+        assert_eq!(adjacent_coords[0].to_index(board_size), 11);
+        assert_eq!(adjacent_coords[1].to_index(board_size), 13);
+        assert_eq!(adjacent_coords[2].to_index(board_size), 7);
+        assert_eq!(adjacent_coords[3].to_index(board_size), 8);
+    }
+
+    // Generate adjacent coordinates for the case that it touches side B and C (corner)
+    #[test]
+    fn test_get_adjacent_coords_toches_b_and_c() {
+        let board_size = 5;
+        let coords = Coordinates::from_index(0, board_size);
+        let adjacent_coords = coords.get_adjacent_coords();
+        assert_eq!(adjacent_coords.len(), 2);
+        assert_eq!(adjacent_coords[0].to_index(board_size), 1);
+        assert_eq!(adjacent_coords[1].to_index(board_size), 2);
+    }
+
+    // Check the mirror of a given coordinate
+    #[test]
+    fn test_get_mirrored_coords() {
+        let vec_coords = vec![2,0,2];
+        let coords = Coordinates::from_vec(&vec_coords).unwrap();
+        let mirrored_coords = coords.get_mirrored_coords();
+        assert_eq!(mirrored_coords.x(), 2);
+        assert_eq!(mirrored_coords.y(), 2);
+        assert_eq!(mirrored_coords.z(), 0);
+    }
+
+
+    // Check the mirror of a center coordinate; it should be the same coordinates
+    #[test]
+    fn test_get_mirrored_coords_center() {
+        let vec_coords = vec![2,1,1];
+        let coords = Coordinates::from_vec(&vec_coords).unwrap();
+        let mirrored_coords = coords.get_mirrored_coords();
+        assert_eq!(mirrored_coords.x(), 2);
+        assert_eq!(mirrored_coords.y(), 1);
+        assert_eq!(mirrored_coords.z(), 1);
     }
 
     // Property-based tests using proptest

--- a/gamey/src/core/coord.rs
+++ b/gamey/src/core/coord.rs
@@ -98,6 +98,65 @@ impl Coordinates {
     pub fn touches_side_c(&self) -> bool {
         self.z == 0
     }
+
+    // Returns a vector with the coordinates of the adjacent cells of this cell.
+    pub fn get_adjacent_coords(&self) -> Vec<Coordinates> {
+
+        // There are six possible adjacent cells, but depending on where the cell is located, some
+        // adjacent cells might not be available.
+        // For example, the cell on the top of the triangle only has 2 adjacent cells available.
+        // So we make sure that we only generate the available adjacent cells by checking whether
+        // the cell is touching some sides of the triangle or not.
+        let mut add_left_cell = true;
+        let mut add_right_cell = true;
+        let mut add_upper_left_cell = true;
+        let mut add_upper_right_cell = true;
+        let mut add_lower_left_cell = true;
+        let mut add_lower_right_cell = true;
+
+        if self.touches_side_a() {
+            add_lower_left_cell = false;
+            add_lower_right_cell = false;
+        }
+
+        if self.touches_side_b() {
+            add_left_cell = false;
+            add_upper_left_cell = false;
+        }
+
+        if self.touches_side_c() {
+            add_right_cell = false;
+            add_upper_right_cell = false;
+        }
+
+        let mut adjancet_cells = Vec::new();
+        if add_left_cell {
+            let left_cell = Coordinates::new(self.x, self.y-1, self.z+1);
+            adjancet_cells.push(left_cell);
+        }
+        if add_right_cell {
+            let right_cell = Coordinates::new(self.x, self.y+1, self.z-1);
+            adjancet_cells.push(right_cell);
+        }
+        if add_upper_left_cell {
+            let upper_left_cell = Coordinates::new(self.x+1, self.y-1, self.z);
+            adjancet_cells.push(upper_left_cell);
+        }
+        if add_upper_right_cell {
+            let upper_right_cell = Coordinates::new(self.x+1, self.y, self.z-1);
+            adjancet_cells.push(upper_right_cell);
+        }
+        if add_lower_left_cell {
+            let lower_left_cell = Coordinates::new(self.x-1, self.y, self.z+1);
+            adjancet_cells.push(lower_left_cell);
+        }
+        if add_lower_right_cell {
+            let lower_right_cell = Coordinates::new(self.x-1, self.y+1, self.z);
+            adjancet_cells.push(lower_right_cell);
+        }
+
+        adjancet_cells
+    }
 }
 
 impl From<Coordinates> for Vec<u32> {

--- a/gamey/src/core/game.rs
+++ b/gamey/src/core/game.rs
@@ -265,7 +265,7 @@ impl GameY {
     }
 
     /// Returns the neighboring coordinates for a given cell.
-    fn get_neighbors(&self, coords: &Coordinates) -> Vec<Coordinates> {
+    pub fn get_neighbors(&self, coords: &Coordinates) -> Vec<Coordinates> {
         let mut neighbors = Vec::new();
         let x = coords.x();
         let y = coords.y();

--- a/webapp/src/__tests__/PlayPage.test.tsx
+++ b/webapp/src/__tests__/PlayPage.test.tsx
@@ -88,8 +88,8 @@ describe('Pruebas unitarias de la página de Partida (PlayPage)', () => {
             onChangeDifficulty={()=>{}}/>
     )
 
-    expect(screen.getByText('Dificultad: Fácil')).toBeTruthy()
-    screen.getByRole('option', { name: /Dificultad: Medio/i }).click();
-    expect(screen.getByText('Dificultad: Medio')).toBeTruthy()
+    expect(screen.getByText('Bot Aleatorio (Fácil)')).toBeTruthy()
+    screen.getByRole('option', { name: /Bot Medio \(Medio\)/i }).click();
+    expect(screen.getByText('Bot Medio (Medio)')).toBeTruthy()
   })
 })

--- a/webapp/src/pages/GamePage.tsx
+++ b/webapp/src/pages/GamePage.tsx
@@ -128,7 +128,9 @@ const GamePage: React.FC<GamePageProps> = ({ user }) => {
               onChange={(e) => setBotId(e.target.value)} 
               className="combobox"
             >
-              <option value="random">Bot Aleatorio (Fácil)</option>
+              <option value="random_bot">Bot Aleatorio (Fácil)</option>
+              <option value="mirrorbot">Bot Espejo (Fácil)</option>
+              <option value="lapabot">Bot Lapa (Medio)</option>
               <option value="mediumbot">Bot Medio (Medio)</option>
               <option value="bridgebot">Bot Puente (Difícil)</option>
             </select>

--- a/webapp/src/pages/GamePage.tsx
+++ b/webapp/src/pages/GamePage.tsx
@@ -132,6 +132,7 @@ const GamePage: React.FC<GamePageProps> = ({ user }) => {
               <option value="mirrorbot">Bot Espejo (Fácil)</option>
               <option value="lapabot">Bot Lapa (Medio)</option>
               <option value="mediumbot">Bot Medio (Medio)</option>
+              <option value="bridgebot_lax">Bot Puente continuo (Difícil)</option>
               <option value="bridgebot">Bot Puente (Difícil)</option>
             </select>
           )}

--- a/webapp/src/pages/PlayPage.tsx
+++ b/webapp/src/pages/PlayPage.tsx
@@ -59,6 +59,7 @@ const PlayPage = ({ user, botId, boardSize, gameMode, player2Name, onBackToLobby
               <option value="mirrorbot">Bot Espejo (Fácil)</option>
               <option value="lapabot">Bot Lapa (Medio)</option>
               <option value="mediumbot">Bot Medio (Medio)</option>
+              <option value="bridgebot_lax">Bot Puente continuo (Difícil)</option>
               <option value="bridgebot">Bot Puente (Difícil)</option>
             </select>
           )}

--- a/webapp/src/pages/PlayPage.tsx
+++ b/webapp/src/pages/PlayPage.tsx
@@ -55,9 +55,11 @@ const PlayPage = ({ user, botId, boardSize, gameMode, player2Name, onBackToLobby
               onChange={handleChangeDifficulty}
               className="combobox"
             >
-              <option value="random_bot">Dificultad: Fácil</option>
-              <option value="mediumbot">Dificultad: Medio</option>
-              <option value="bridgebot">Dificultad: Difícil</option>
+              <option value="random_bot">Bot Aleatorio (Fácil)</option>
+              <option value="mirrorbot">Bot Espejo (Fácil)</option>
+              <option value="lapabot">Bot Lapa (Medio)</option>
+              <option value="mediumbot">Bot Medio (Medio)</option>
+              <option value="bridgebot">Bot Puente (Difícil)</option>
             </select>
           )}
 


### PR DESCRIPTION
Issue #171 

- Se añade bot espejo, dificultad fácil (espeja los movimientos del jugador, salvo si se coloca en el centro que realiza un movimiento aleatorio).
- Se añade bot lapa (dificultad media), que prioriza colocar su ficha al lado de fichas del jugador que tengan el menor número de fichas adyacentes.
- Se añade variante del bot bridgebot llamada Bot puente continuo que no intenta reparar puentes con tanta frecuencia que el bridgebot original.

Además, se arregla el bug #200